### PR TITLE
Allow overriding the filter for listener return values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
 - "4.0"
-- "4.2.2"
+- "4.2.3"
+- "5"
 matrix:
   fast_finish: true
 script: "npm run-script test-travis"
 after_script: "npm install coveralls && cat ./coverage/lcov.info | coveralls"
+sudo: false

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The emitter can work either synchronously or asynchrnously. However, all events 
 ### Usage
 
 
-```
+```javascript
 const EventEmitter = require('promise-events');
 
 var events = new EventEmitter();
 
-// synchrnous
+// synchronous
 events.on('syncEvent', function (hello) {
   console.log(hello);
 });
@@ -41,13 +41,13 @@ Promise.all([
 
   events.emit('asyncEvent', 'Hello async!').then(function (results) {
     console.log(results);
-    // results = [ 'Bye!' ]
+    // results = [ 'Bye!', undefined ]
   });
 
 });
 ```
 
-All listeners are executed using [`Promise.all`](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all), and empty results (listeners returning no result or `undefined`) are filtered out. This can be overridden by `events.setResultFilter(filter)`to specify a custom filter or `events.setResultFilter(null)` in order to return all return values, even empty ones. The order of the items in `results` is undefined. Therefore, the number of listeners and the order they are added to the emitter does not garantee the order or number of values returned when emitting an event; do not rely on `results` to determine a listener's return value.
+All listeners are executed using [`Promise.all`](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all). You can specify a filter function for the array of return values using `events.setResultFilter(filter)` (resp. `events.getResultFilter()` and `EventEmitter.defaultResultFilter`, analogous to `EventEmitter.defaultMaxListeners`). The order of the items in `results` is undefined. Therefore, the number of listeners and the order they are added to the emitter does not garantee the order or number of values returned when emitting an event; do not rely on `results` to determine a listener's return value.
 
 A call to `events.emit` will always resolve with an array if successful or be rejected with a single `Error` upon any failure, at any given time, for any number of listeners (i.e. the first error thrown will be passed to the rejection callback and all subsequent will be ignored).
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Promise.all([
 });
 ```
 
-All listeners are executed using [`Promise.all`](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all), and empty results (listeners returning no result or `undefined`) are filtered out. The order of the items in `results` is undefined. Therefore, the number of listeners and the order they are added to the emitter does not garantee the order or number of values returned when emitting an event; do not rely on `results` to determine a listener's return value.
+All listeners are executed using [`Promise.all`](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all), and empty results (listeners returning no result or `undefined`) are filtered out. This can be overridden by `events.setResultFilter(filter)`to specify a custom filter or `events.setResultFilter(null)` in order to return all return values, even empty ones. The order of the items in `results` is undefined. Therefore, the number of listeners and the order they are added to the emitter does not garantee the order or number of values returned when emitting an event; do not rely on `results` to determine a listener's return value.
 
 A call to `events.emit` will always resolve with an array if successful or be rejected with a single `Error` upon any failure, at any given time, for any number of listeners (i.e. the first error thrown will be passed to the rejection callback and all subsequent will be ignored).
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "istanbul": "^0.4.0",
     "mocha": "^2.3.4",
-    "should": "^7.1.1"
+    "should": "^8.0.2"
   },
   "engines" : {
     "node" : ">=4.0.0"

--- a/test/emit.test.js
+++ b/test/emit.test.js
@@ -64,14 +64,14 @@ describe("Test emitting events", function () {
       return events.addListener('foo', fn).then(function () {
         return events.emit('foo').then(function (results) {
 
-          results.should.be.an.instanceOf(Array).and.have.lengthOf(0);
+          results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
 
           Emitter.listenerCount(events, 'foo').should.equal(1);
 
           return events.on('foo', fn).then(function () {
             return events.emit('foo').then(function (results) {
 
-              results.should.be.an.instanceOf(Array).and.have.lengthOf(0);
+              results.should.be.an.instanceOf(Array).and.have.lengthOf(2);
 
               events.listeners('foo').should.be.an.instanceOf(Array).and.have.lengthOf(2);
               Emitter.listenerCount(events, 'foo').should.equal(2);
@@ -334,7 +334,7 @@ describe("Test emitting events", function () {
 
         return events.emit('foo').then(function (results) {
 
-          results.should.be.an.instanceOf(Array).and.have.lengthOf(0);
+          results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
 
           events._events.should.not.have.ownProperty('foo');
 
@@ -343,7 +343,7 @@ describe("Test emitting events", function () {
 
             return events.emit('foo').then(function (results) {
 
-              results.should.be.an.instanceOf(Array).and.have.lengthOf(0);
+              results.should.be.an.instanceOf(Array).and.have.lengthOf(2);
 
               events._events.should.not.have.ownProperty('foo');
             });
@@ -610,7 +610,7 @@ describe("Test emitting events", function () {
 
   describe('Filtering the listener return values', function () {
     
-    it('should filter out undefined results by default', function () {
+    it('should not filter out undefined results by default', function () {
       let events = new Emitter();
       
       return Promise.all([
@@ -619,7 +619,7 @@ describe("Test emitting events", function () {
         events.on('foo', function() { return 2; }),
       ]).then(function() {
         return events.emit('foo').then(function(results) {
-          results.sort().should.deepEqual([1, 2]);
+          results.sort().should.deepEqual([undefined, 1, 2].sort());
         });
       });
     });
@@ -645,10 +645,10 @@ describe("Test emitting events", function () {
       });
     });
     
-    it("should accept a custom 'null' filter", function() {
+    it("should accept a custom 'undefined' filter", function() {
       let events = new Emitter();
       
-      events.setResultFilter(null);
+      events.setResultFilter(undefined);
       
       return Promise.all([
         events.on('foo', function() { return undefined; }),

--- a/test/emit.test.js
+++ b/test/emit.test.js
@@ -9,7 +9,7 @@ describe("Test emitting events", function () {
 
   describe("Emitting events", function () {
 
-    it("should emit 'newListener'", function (done) {
+    it("should emit 'newListener'", function () {
       let events = new Emitter();
       let fnFoo = function foo() {};
       let fnBar = function bar() {};
@@ -17,7 +17,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.addListener('newListener', function (type, listener) {
+      return events.addListener('newListener', function (type, listener) {
         listeners[type] = listener;
       }).then(function () {
         return events.addListener('foo', fnFoo).then(events.on('bar', fnBar)).then(function () {
@@ -26,18 +26,18 @@ describe("Test emitting events", function () {
           listeners.should.have.ownProperty('bar').and.equal(fnBar);
 
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit 'removeListener'", function (done) {
+    it("should emit 'removeListener'", function () {
       let events = new Emitter();
       let fn = function () {};
       let listeners = { 'foo': fn };
 
       this.timeout(1000);
 
-      events.addListener('removeListener', function (type, listener) {
+      return events.addListener('removeListener', function (type, listener) {
         listener.should.equal(listeners[type]);
 
         listeners[type] = false;
@@ -49,11 +49,11 @@ describe("Test emitting events", function () {
 
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with no arguments", function (done) {
+    it("should emit with no arguments", function () {
       let events = new Emitter();
       let fn = function () {
         arguments.should.have.lengthOf(0);
@@ -61,7 +61,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.addListener('foo', fn).then(function () {
+      return events.addListener('foo', fn).then(function () {
         return events.emit('foo').then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(0);
@@ -79,11 +79,11 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with one argument", function (done) {
+    it("should emit with one argument", function () {
       let events = new Emitter();
       let a = 'Hello';
       let fn = function (arg1) {
@@ -96,7 +96,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.addListener('foo', fn).then(function () {
+      return events.addListener('foo', fn).then(function () {
         return events.emit('foo', a).then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -110,11 +110,11 @@ describe("Test emitting events", function () {
             should(results[1]).equal(a);
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with two argument", function (done) {
+    it("should emit with two argument", function () {
       let events = new Emitter();
       let a = 'Hello';
       let b = 'World';
@@ -137,7 +137,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.addListener('foo', fn1).then(function () {
+      return events.addListener('foo', fn1).then(function () {
         return events.emit('foo', a, b).then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -151,11 +151,11 @@ describe("Test emitting events", function () {
             should(results[1]).equal(b);
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with three argument", function (done) {
+    it("should emit with three argument", function () {
       let events = new Emitter();
       let a = 'Hello';
       let b = 'World';
@@ -190,7 +190,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.addListener('foo', fn1).then(function () {
+      return events.addListener('foo', fn1).then(function () {
         return events.emit('foo', a, b, c).then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -214,11 +214,11 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with many argument", function (done) {
+    it("should emit with many argument", function () {
       let events = new Emitter();
       let args = ['a', 'b', 'c', 'd'];
       function fnGenerator(retVal) {
@@ -230,7 +230,7 @@ describe("Test emitting events", function () {
         }
       }
 
-      events.addListener('foo', fnGenerator(1)).then(function () {
+      return events.addListener('foo', fnGenerator(1)).then(function () {
         return events.emit('foo', 'a', 'b', 'c', 'd').then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -245,7 +245,7 @@ describe("Test emitting events", function () {
 
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
   });
@@ -253,7 +253,7 @@ describe("Test emitting events", function () {
 
   describe("Emitting event once", function () {
 
-    it("should emit 'newListener'", function (done) {
+    it("should emit 'newListener'", function () {
       let events = new Emitter();
       let fnFoo = function foo() {};
       let fnBar = function bar() {};
@@ -261,7 +261,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.addListener('newListener', function (type, listener) {
+      return events.addListener('newListener', function (type, listener) {
         listeners[type] = listener;
       }).then(function () {
         return events.once('foo', fnFoo).then(events.on('bar', fnBar)).then(function () {
@@ -270,18 +270,18 @@ describe("Test emitting events", function () {
           listeners.should.have.ownProperty('bar').and.equal(fnBar);
 
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit 'removeListener'", function (done) {
+    it("should emit 'removeListener'", function () {
       let events = new Emitter();
       let fn = function () {};
       let listeners = { 'foo': fn };
 
       this.timeout(1000);
 
-      events.addListener('removeListener', function (type, listener) {
+      return events.addListener('removeListener', function (type, listener) {
         listener.should.equal(listeners[type]);
 
         listeners[type] = false;
@@ -293,18 +293,18 @@ describe("Test emitting events", function () {
 
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit 'newListener' only once", function (done) {
+    it("should emit 'newListener' only once", function () {
       let events = new Emitter();
       let fn = function () {};
       let newHandlerCount = 0;
 
       this.timeout(1000);
 
-      events.once('newListener', function (type, listener) {
+      return events.once('newListener', function (type, listener) {
         ++newHandlerCount;
       }).then(function () {
         newHandlerCount.should.equal(0);
@@ -316,12 +316,12 @@ describe("Test emitting events", function () {
           events._eventsCount.should.equal(2);
 
         });
-      }).then(done).catch(done);
+      });
 
     });
 
 
-    it("should emit with no arguments", function (done) {
+    it("should emit with no arguments", function () {
       let events = new Emitter();
       let fn = function () {
         arguments.should.have.lengthOf(0);
@@ -329,7 +329,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.once('foo', fn).then(function () {
+      return events.once('foo', fn).then(function () {
         events._events.should.have.ownProperty('foo').and.be.a.Function;
 
         return events.emit('foo').then(function (results) {
@@ -349,11 +349,11 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with one argument", function (done) {
+    it("should emit with one argument", function () {
       let events = new Emitter();
       let a = 'Hello';
       let fn = function (arg1) {
@@ -366,7 +366,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.once('foo', fn).then(function () {
+      return events.once('foo', fn).then(function () {
         return events.emit('foo', a).then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -386,11 +386,11 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with two argument", function (done) {
+    it("should emit with two argument", function () {
       let events = new Emitter();
       let a = 'Hello';
       let b = 'World';
@@ -413,7 +413,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.once('foo', fn1).then(function () {
+      return events.once('foo', fn1).then(function () {
         return events.emit('foo', a, b).then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -433,11 +433,11 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with three argument", function (done) {
+    it("should emit with three argument", function () {
       let events = new Emitter();
       let a = 'Hello';
       let b = 'World';
@@ -472,7 +472,7 @@ describe("Test emitting events", function () {
 
       this.timeout(1000);
 
-      events.once('foo', fn1).then(function () {
+      return events.once('foo', fn1).then(function () {
         return events.emit('foo', a, b, c).then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -504,11 +504,11 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
 
-    it("should emit with many argument", function (done) {
+    it("should emit with many argument", function () {
       let events = new Emitter();
       let args = ['a', 'b', 'c', 'd'];
       function fnGenerator(retVal) {
@@ -520,7 +520,7 @@ describe("Test emitting events", function () {
         }
       }
 
-      events.once('foo', fnGenerator(1)).then(function () {
+      return events.once('foo', fnGenerator(1)).then(function () {
         return events.emit('foo', 'a', 'b', 'c', 'd').then(function (results) {
 
           results.should.be.an.instanceOf(Array).and.have.lengthOf(1);
@@ -539,7 +539,7 @@ describe("Test emitting events", function () {
             });
           });
         });
-      }).then(done).catch(done);
+      });
     });
 
   });
@@ -549,63 +549,63 @@ describe("Test emitting events", function () {
   describe('Test errors', function () {
 
 
-    it('should reject error instance when no error listeners', function (done) {
+    it('should reject error instance when no error listeners', function () {
       let events = new Emitter();
 
-      events.emit('error', new Error('Test Error')).then(function () {
+      return events.emit('error', new Error('Test Error')).then(function () {
         throw new Error('Failed test');
       }, function (err) {
         err.should.be.instanceOf(Error).and.have.ownProperty('message').equal('Test Error');
-      }).then(done).catch(done);
+      });
     });
 
-    it('should reject error string when no error listeners', function (done) {
+    it('should reject error string when no error listeners', function () {
       let events = new Emitter();
 
-      events.emit('error', 'Test string').then(function () {
+      return events.emit('error', 'Test string').then(function () {
         throw new Error('Failed test');
       }, function (err) {
         err.should.be.instanceOf(Error).and.have.ownProperty('message').equal('Uncaught, unspecified "error" event. (Test string)');
-      }).then(done).catch(done);
+      });
     });
 
-    it('should reject undefined error when no error listeners', function (done) {
+    it('should reject undefined error when no error listeners', function () {
       let events = new Emitter();
 
-      events.emit('error').then(function () {
+      return events.emit('error').then(function () {
         throw new Error('Failed test');
       }, function (err) {
         err.should.be.instanceOf(Error).and.have.ownProperty('message').equal('Uncaught, unspecified "error" event.');
-      }).then(done).catch(done);
+      });
     });
 
-    it('should reject even with undefined _events', function (done) {
+    it('should reject even with undefined _events', function () {
       let events = new Emitter();
 
       events._events = null;
 
-      events.emit('error').then(function () {
+      return events.emit('error').then(function () {
         throw new Error('Failed test');
       }, function (err) {
         err.should.be.instanceOf(Error).and.have.ownProperty('message').equal('Uncaught, unspecified "error" event.');
-      }).then(done).catch(done);
+      });
     });
 
   });
 
 
-  it('should resolve on missing listeners', function (done) {
+  it('should resolve on missing listeners', function () {
     let events = new Emitter();
 
-    events.emit('missing').then(done);
+    return events.emit('missing');
   });
 
-  it('should resolve on missing listeners with undefined _events', function (done) {
+  it('should resolve on missing listeners with undefined _events', function () {
     let events = new Emitter();
 
     events._events = null;
 
-    events.emit('missing').then(done);
+    return events.emit('missing');
   });
 
 });

--- a/test/emit.test.js
+++ b/test/emit.test.js
@@ -608,4 +608,67 @@ describe("Test emitting events", function () {
     return events.emit('missing');
   });
 
+  describe('Filtering the listener return values', function () {
+    
+    it('should filter out undefined results by default', function () {
+      let events = new Emitter();
+      
+      return Promise.all([
+        events.on('foo', function() { return undefined; }),
+        events.on('foo', function() { return 1; }),
+        events.on('foo', function() { return 2; }),
+      ]).then(function() {
+        return events.emit('foo').then(function(results) {
+          results.sort().should.deepEqual([1, 2]);
+        });
+      });
+    });
+
+    it('should accept custom result filters', function() {
+      let events = new Emitter();
+      
+      function filter(value) {
+        return value !== 2;
+      }
+      
+      events.setResultFilter(filter);
+      events._resultFilter.should.equal(filter);
+      
+      return Promise.all([
+        events.on('foo', function() { return undefined; }),
+        events.on('foo', function() { return 1; }),
+        events.on('foo', function() { return 2; }),
+      ]).then(function() {
+        return events.emit('foo').then(function(results) {
+          results.sort().should.deepEqual([undefined, 1].sort());
+        });
+      });
+    });
+    
+    it("should accept a custom 'null' filter", function() {
+      let events = new Emitter();
+      
+      events.setResultFilter(null);
+      
+      return Promise.all([
+        events.on('foo', function() { return undefined; }),
+        events.on('foo', function() { return 1; }),
+        events.on('foo', function() { return 2; }),
+      ]).then(function() {
+        return events.emit('foo').then(function(results) {
+          results.sort().should.deepEqual([undefined, 1, 2].sort());
+        });
+      });
+    });
+    
+    it('should throw when adding invalid filters', function() {
+      let events = new Emitter();
+      
+      try {
+        events.setResultFilter(42);
+      } catch (err) {
+        err.should.be.instanceOf(Error).and.have.ownProperty('message').equal('filter must be a function');
+      }
+    });
+  });
 });

--- a/test/inheritance.test.js
+++ b/test/inheritance.test.js
@@ -6,7 +6,7 @@ describe("Test inheritance", function () {
   const Emitter = require('../emitter');
 
 
-  it("should create valid instance", function (done) {
+  it("should create valid instance", function () {
     const util = require('util');
     const SubEmitter = function () {};
 
@@ -21,12 +21,12 @@ describe("Test inheritance", function () {
     events.should.not.have.ownProperty('_events');
     events.should.not.have.ownProperty('_eventsCount');
 
-    events.on('foo', function () {}).then(function () {
+    return events.on('foo', function () {}).then(function () {
 
       events.should.have.ownProperty('_events').and.have.ownProperty('foo').be.a.Function;
       events.should.have.ownProperty('_eventsCount').equal(1);
 
-    }).then(done).catch(done);
+    });
 
   });
 

--- a/test/listeners.test.js
+++ b/test/listeners.test.js
@@ -6,7 +6,7 @@ describe("Test adding and removing listeners", function () {
   var should = require('should');
 
 
-  it("should add and remove listeners", function (done) {
+  it("should add and remove listeners", function () {
     var events = new Emitter();
     var fn = function () {};
 
@@ -14,7 +14,7 @@ describe("Test adding and removing listeners", function () {
 
     events._eventsCount.should.equal(0);
 
-    events.addListener('foo', fn).then(function () {
+    return events.addListener('foo', fn).then(function () {
       events._eventsCount.should.equal(1);
       events._events['foo'].should.equal(fn);
 
@@ -39,14 +39,14 @@ describe("Test adding and removing listeners", function () {
       events._events.should.eql({});
 
       return events.removeListener('buz', fn);
-    }).then(done).catch(done);
+    });
   });
 
 
-  it("should not add invalid listeners", function (done) {
+  it("should not add invalid listeners", function () {
     var events = new Emitter();
 
-    Promise.all([undefined, null, false, true, -1, 0, 1, '', {}, [], /./].map(function (invalid) {
+    return Promise.all([undefined, null, false, true, -1, 0, 1, '', {}, [], /./].map(function (invalid) {
       try {
         events.on('foo', invalid).then(function () {
           throw new Error("Should not allow adding invalid listener : " + invalid);
@@ -63,16 +63,14 @@ describe("Test adding and removing listeners", function () {
         e.message.should.equal('listener must be a function');
       }
 
-    })).then(function () {
-      done();
-    }).catch(done);
+    }));
   });
 
 
-  it("should not remove invalid listeners", function (done) {
+  it("should not remove invalid listeners", function () {
     var events = new Emitter();
 
-    Promise.all([undefined, null, false, true, -1, 0, 1, '', {}, [], /./].map(function (invalid) {
+    return Promise.all([undefined, null, false, true, -1, 0, 1, '', {}, [], /./].map(function (invalid) {
       try {
         events.removeListener('foo', invalid).then(function () {
           throw new Error("Should not allow removing invalid listener : " + invalid);
@@ -80,20 +78,18 @@ describe("Test adding and removing listeners", function () {
       } catch (e) {
         e.message.should.equal('listener must be a function');
       }
-    })).then(function () {
-      done();
-    }).catch(done);
+    }));
   });
 
 
 
-  it("should remove all listeners", function (done) {
+  it("should remove all listeners", function () {
     var events = new Emitter();
     var fn = function () {};
 
     this.timeout(1000);
 
-    Promise.all([
+    return Promise.all([
       events.on('foo', fn),
       events.on('foo', fn),
       events.on('foo', fn),
@@ -147,20 +143,20 @@ describe("Test adding and removing listeners", function () {
       }).then(function () {
         should(events._events).be.null;
         events._eventsCount.should.equal(0);
-      })
+      });
 
-    }).then(done).catch(done);
+    });
   });
 
 
-  it("should handle emitted errors", function (done) {
+  it("should handle emitted errors", function () {
     var events = new Emitter();
 
-    events.on('foo', function () {
+    return events.on('foo', function () {
       throw new Error('Test');
     }).then(function () {
 
-      Promise.all([
+      return Promise.all([
         events.emit('foo').then(function () {
           throw new Error('Failed test');
         }, function (err) {
@@ -186,9 +182,7 @@ describe("Test adding and removing listeners", function () {
         }, function (err) {
           err.message.should.equal('Test');
         })
-      ]).then(function () {
-        done();
-      }).catch(done);
+      ]);
 
     });
 

--- a/test/maxListeners.test.js
+++ b/test/maxListeners.test.js
@@ -1,5 +1,6 @@
-
 'use strict';
+
+const should = require('should');
 
 describe("Test maxListeners", function () {
 

--- a/test/resultFilter.test.js
+++ b/test/resultFilter.test.js
@@ -1,0 +1,45 @@
+
+'use strict';
+
+describe("Test resultFilter", function () {
+
+  const Emitter = require('../emitter');
+  let _resultFilter;
+
+  before(function () {
+    _resultFilter = Emitter.defaultResultFilter;
+  });
+
+  after(function () {
+    Emitter.defaultResultFilter = _resultFilter;
+  });
+
+
+  it('should throw when adding invalid filters', function () {
+    let events = new Emitter();
+
+    [
+      true, 'foo', /./, 42, {}, [], -1
+    ].forEach(function (n) {
+      !function () { events.resultFilter = n; }.should.throw('filter must be a function');
+    });
+  });
+
+
+  it('should reciprocate', function () {
+    let events = new Emitter();
+    
+    (typeof events.getResultFilter()).should.equal('undefined');
+
+    const exampleFilter = function() { return true; };
+    Emitter.defaultResultFilter = exampleFilter;
+    Emitter.defaultResultFilter.should.equal(exampleFilter);
+
+    events.resultFilter = undefined;
+    events.resultFilter.should.equal(Emitter.defaultResultFilter);
+
+    Emitter.defaultMaxListeners = undefined;
+    (typeof Emitter.defaultMaxListeners).should.equal('undefined');
+    (typeof events.maxListeners).should.equal('undefined');
+  });
+});


### PR DESCRIPTION
Introduce a `.setResultFilter()` method which can be used to override the default filter for listener results. Previously, empty results were always filtered out, which may not be the desired behaviour in all cases (and in fact, in the application where I’m using this, knowing that the existence of a listener implies the existence of an entry in the results array would be pretty helpful).

This PR contains some meta stuff like Travis CI and Dependency updates; Feel free to cherry-pick   a07d281 out, if you don’t want the rest of the changes; All modifications are covered by tests and documented briefly in the readme.