### PR TITLE
Fix Node.js v6 (upcoming) tests

### DIFF
--- a/test/maxListeners.test.js
+++ b/test/maxListeners.test.js
@@ -22,7 +22,7 @@ describe("Test maxListeners", function () {
     [
       undefined, null, false, true, '', 'foo', /./, function () {}, {}, [], -1, NaN
     ].forEach(function (n) {
-      !function () { events.maxListeners = n; }.should.throw('n must be a positive number');
+      !function () { events.maxListeners = n; }.should.throw(/must be a positive number/);
     });
   });
 


### PR DESCRIPTION
In nodejs/node@20285ad177551, the error message for passing an invalid argument to EventEmitter.setMaxListeners was changed, which this module explicitly tests for.

This fixes this test when using the current Node.js master branch.