### PR TITLE
Fix types for resultFilter getter/setter

### DIFF
--- a/emitter.d.ts
+++ b/emitter.d.ts
@@ -1,5 +1,5 @@
 declare type TEventType = string | symbol;
-declare type TListener = (...args: any[]) => void;
+declare type TListener = (...args: any[]) => Promise<any>;
 declare type TFilter<T = any> = {
     <S extends T>(callbackfn: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
     (callbackfn: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];

--- a/emitter.d.ts
+++ b/emitter.d.ts
@@ -12,9 +12,9 @@ declare class EventEmitter {
     get maxListeners(): number;
     set maxListeners(n: number);
     getResultFilter(): TFilter | undefined;
-    setResultFilter(filter: TFilter): this;
+    setResultFilter(filter: TFilter | undefined): this;
     get resultFilter(): TFilter | undefined;
-    set resultFilter(filter: TFilter);
+    set resultFilter(filter: TFilter | undefined);
     emit(type: TEventType, ...args: any[]): Promise<any>;
     addListener(type: TEventType, listener: TListener): Promise<any>;
     prependListener(type: TEventType, listener: TListener): Promise<any>;


### PR DESCRIPTION
Using this library in another project, TypeScript surprisingly fails to compile (I thought it doesn't care about dependency typings, but apparently it does):

```
node_modules/promise-events/emitter.d.ts:16:9 - error TS2380: 'get' and 'set' accessor must have the same type.

16     get resultFilter(): TFilter | undefined;
           ~~~~~~~~~~~~

node_modules/promise-events/emitter.d.ts:17:9 - error TS2380: 'get' and 'set' accessor must have the same type.

17     set resultFilter(filter: TFilter);
           ~~~~~~~~~~~~

```

However, the implementation of `set resultFilter` handles the case of an undefined parameter, and the class `EventEmitter` also handles an undefined result filter, which is the default value.

This patch fixes the typings by adding undefined as a possible parameter.

Note that strictly speaking, `set resultFilter` also supports a null parameter, but that's the only occurrence of null in the code, so I prefer not to document it publicly.